### PR TITLE
Delete Cartfile.resolved

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,0 @@
-github "apollostack/apollo-ios" "0.5.1"


### PR DESCRIPTION
this is causing resolution to older version / not latest. 

➜  frontpage-ios-app git:(master) ✗ carthage bootstrap --platform iOS
*** No Cartfile.resolved found, updating dependencies
*** Fetching apollo-ios
*** Fetching SQLite.swift
*** Checking out apollo-ios at "0.6.5" <- picking up correct version after Cartfile.resolved is deleted
*** Checking out SQLite.swift at "0.11.3"
*** xcodebuild output can be found in /var/folders/jz/lf_rj_ln1712tyf0pd9jq8f00000gn/T/carthage-xcodebuild.F6oyXh.log
*** Building scheme "SQLite iOS" in SQLite.xcodeproj
*** Building scheme "Apollo" in Apollo.xcworkspace