### PR TITLE
Fix readme to refer to xcworkspace instead of xcodeproj

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This app talks to the frontpage example server, available here: https://github.c
 
 ## Starting the app
 
-You can then open `FrontPage.xcodeproj` and press the run button to run the app. It should load a list of posts and display their titles, authors and number of votes in a table view. You can also upvote posts.
+You can then open `FrontPage.xcworkspace` and press the run button to run the app. It should load a list of posts and display their titles, authors and number of votes in a table view. You can also upvote posts.
 
 If you want to run on a device, change `localhost` to your machine's local IP address in `AppDelegate.swift`.
 


### PR DESCRIPTION
Pulled this repo and noticed that Apollo was installed via CocoaPods instead of directly into the xcodeproj file as a framework. The readme should be updated to reflect this.

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] has-reproduction
- [ ] feature
- [ ] blocking
- [ ] good first review

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->